### PR TITLE
FIX Update i18n plurals, block type, add title to template and clearfix underneath form

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,0 +1,8 @@
+en:
+  DNADesign\ElementalUserForms\Model\ElementForm:
+    BlockType: Form
+    PLURALNAME: forms
+    PLURALS:
+      one: 'A form'
+      other: '{count} forms'
+    SINGULARNAME: form

--- a/src/Model/ElementForm.php
+++ b/src/Model/ElementForm.php
@@ -12,25 +12,15 @@ class ElementForm extends BaseElement
 {
     use UserForm;
 
-    /**
-     * @var string
-     */
     private static $table_name = 'ElementForm';
 
-    /**
-     * @var string
-     */
-    private static $title = 'Form';
-
-    /**
-     * @var string
-     */
     private static $icon = 'dnadesign/silverstripe-elemental-userforms:images/form.svg';
 
-    /**
-     * @var string
-     */
     private static $controller_class = ElementFormController::class;
+
+    private static $singular_name = 'form';
+
+    private static $plural_name = 'forms';
 
     /**
      * @return UserForm
@@ -69,5 +59,10 @@ class ElementForm extends BaseElement
         }
 
         return parent::Link($action);
+    }
+
+    public function getType()
+    {
+        return _t(__CLASS__ . '.BlockType', 'Form');
     }
 }

--- a/templates/DNADesign/ElementalUserForms/Model/ElementForm.ss
+++ b/templates/DNADesign/ElementalUserForms/Model/ElementForm.ss
@@ -1,3 +1,8 @@
-<div class="formelement__form">
+<div class="form-element__form $ExtraClass">
+    <% if $Title && $ShowTitle %>
+        <h2 class="form-element__title">$Title</h2>
+    <% end_if %>
+
     $ElementForm
 </div>
+<div style="clear: both"></div>


### PR DESCRIPTION
Changes:

* Switch BEM class naming to use dashes for word separators (fixes #7)
* Update i18n singular and plural names (fixes #8)
* Add block type API which replaced `private static $title`
* Add title to template (fixes #6) and add ExtraClass to container which was missing
* Add clearfix underneath container to ensure that userform actions don't mix up with the next block