### PR TITLE
NEW Move Title and Displayed to the top of the Form Fields tab

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,0 +1,6 @@
+---
+Name: elementaluserformsconfig
+---
+DNADesign\ElementalUserForms\Model\ElementForm:
+  extensions:
+    - DNADesign\ElementalUserForms\Extension\ElementFormExtension

--- a/src/Extension/ElementFormExtension.php
+++ b/src/Extension/ElementFormExtension.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DNADesign\ElementalUserForms\Extension;
+
+use SilverStripe\Forms\FieldGroup;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\TextField;
+use SilverStripe\Forms\CheckboxField;
+use SilverStripe\ORM\DataExtension;
+
+class ElementFormExtension extends DataExtension
+{
+    public function updateCMSFields(FieldList $fields)
+    {
+        $this->moveTitleAndDisplayedCheckbox($fields);
+    }
+
+    /**
+     * Move the Title and Displayed checkbox from the Content to Form Fields tab
+     *
+     * @param FieldList $fields
+     * @return $this
+     */
+    protected function moveTitleAndDisplayedCheckbox(FieldList $fields)
+    {
+        /** @see DNADesign\Elemental\Models\BaseElement */
+        $composite = $fields->fieldByName('Root.Main.TitleAndDisplayed');
+
+        $fields->removeByName('TitleAndDisplayed');
+        $fields->findOrMakeTab('Root.FormFields')->unshift($composite);
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Start of #13, moves the Title and Displayed checkboxes into the top of the Form Fields tab

![image](https://user-images.githubusercontent.com/5170590/32083489-5b7199da-bb1f-11e7-89d9-194aef19d44d.png)

Requires https://github.com/dnadesign/silverstripe-elemental/pull/133