### PR TITLE
DOCS Update readme with how to block default CSS and JS from UserForms

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ There are valid use cases where this might be what you want (or variations of it
 applying the ElementalPageExtension to subclasses of Page and excluding the UserDefinedForm class from this
 extension to avoid this situation from happening.
 
+## Blocking default CSS and JS
+
+[silverstripe/silverstripe-userforms](https://github.com/silverstripe/silverstripe-userforms) includes default CSS and Javascript. If you want to block them from being included in your page when using `ElementForm`, you will need to set the configuration flag at the `ElementForm` level.
+
+``` yaml
+DNADesign\ElementalUserForms\Model\ElementForm:
+  block_default_userforms_js: true
+  block_default_userforms_css: true
+```
+
 ## Versioning
 
 This library follows [Semver](http://semver.org). According to Semver, you will be able to upgrade to any minor or patch version of this library without any breaking changes to the public API. Semver also requires that we clearly define the public API for this library.


### PR DESCRIPTION
Discovered that when using `ElementForm`, blocking default CSS and JS at the level of the object extended by `ElementalPageExtension` doesn't work. You have to do it at the `ElementForm` level.

Updated the README accordingly.

Resolves #25