### PR TITLE
NEW Disable inline editing for form blocks in elemental 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,18 @@ dist: trusty
 
 env:
   global:
-    - COMPOSER_ROOT_VERSION=1.x-dev
+    - COMPOSER_ROOT_VERSION=2.x-dev
 
 matrix:
   include:
     - php: 5.6
-      env: DB=MYSQL RECIPE_VERSION="4.2.x-dev" PHPCS_TEST=1 PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION="4.3.x-dev" PHPCS_TEST=1 PHPUNIT_TEST=1
     - php: 7.0
-      env: DB=MYSQL RECIPE_VERSION="4.2.x-dev" PHPUNIT_TEST=1
-    - php: 7.1
       env: DB=MYSQL RECIPE_VERSION="4.3.x-dev" PHPUNIT_TEST=1
+    - php: 7.1
+      env: DB=MYSQL RECIPE_VERSION="4.4.x-dev" PHPUNIT_TEST=1
     - php: 7.2
-      env: DB=PGSQL RECIPE_VERSION="4.3.x-dev"PHPUNIT_COVERAGE_TEST=1
+      env: DB=PGSQL RECIPE_VERSION="4.4.x-dev" PHPUNIT_COVERAGE_TEST=1
     - php: 7.2
       env: DB=MYSQL RECIPE_VERSION="4.x-dev" PHPUNIT_TEST=1
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ content block called "Form", which can be used to create user defined forms.
 ## Requirements
 
 * SilverStripe ^4.0
-* Elemental ^2.0
+* Elemental ^4.0
 * UserForms ^5.0
 
 ## Installation
@@ -23,7 +23,7 @@ content block called "Form", which can be used to create user defined forms.
 Install with Composer:
 
 ```
-composer require dnadesign/silverstripe-elemental-userforms 1.x-dev
+composer require dnadesign/silverstripe-elemental-userforms 2.x-dev
 ```
 
 Ensure you run `dev/build?flush=1` to build your database and flush your cache.
@@ -47,6 +47,11 @@ module by default.
 There are valid use cases where this might be what you want (or variations of it), however we would recommend
 applying the ElementalPageExtension to subclasses of Page and excluding the UserDefinedForm class from this
 extension to avoid this situation from happening.
+
+## Inline editing
+
+Please note that form elements are not inline editable. Clicking on them in the CMS will take you to a GridField
+edit form instead.
 
 ## Blocking default CSS and JS
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "dnadesign/silverstripe-elemental": "^3.0",
+        "dnadesign/silverstripe-elemental": "^4.0@dev",
         "silverstripe/userforms": "^5.0",
         "silverstripe/vendor-plugin": "^1.0"
     },

--- a/src/Model/ElementForm.php
+++ b/src/Model/ElementForm.php
@@ -22,6 +22,8 @@ class ElementForm extends BaseElement
 
     private static $plural_name = 'forms';
 
+    private static $inline_editable = false;
+
     /**
      * @return UserForm
      */


### PR DESCRIPTION
Resolves https://github.com/dnadesign/silverstripe-elemental-userforms/issues/33 and bumps the elemental minimum to 4.x