### PR TITLE
Update for Elemental 4.0.0 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"require": {
-		"dnadesign/silverstripe-elemental": "^2 || ^3",
+		"dnadesign/silverstripe-elemental": "^2 || ^3 || ^4",
 		"silverstripe/userforms": "^5",
         "silverstripe/vendor-plugin": "^1.0"
 	},


### PR DESCRIPTION
Elemental is at v4.0 now so if you try to upgrade you can't when using this module.