### PR TITLE
Use Link() method which is created to override parent function in the first place

### DIFF
--- a/src/Model/ElementForm.php
+++ b/src/Model/ElementForm.php
@@ -40,7 +40,7 @@ class ElementForm extends BaseElement
         $form = $controller->Form();
         $form->setFormAction(
             Controller::join_links(
-                $current->Link(),
+                $this->Link(),
                 'element',
                 $this->owner->ID,
                 'Form'


### PR DESCRIPTION
This class has implemented a `Link()` method on line `53` and it looks like using it makes more sense to associate it with the `Form()` method defined.
