### PR TITLE
ENH Duplicate child fields on duplicate

### DIFF
--- a/src/Model/ElementForm.php
+++ b/src/Model/ElementForm.php
@@ -68,4 +68,9 @@ class ElementForm extends BaseElement
     {
         return _t(__CLASS__ . '.BlockType', 'Form');
     }
+
+    public function duplicate($doWrite = true, $relations = null)
+    {
+        return parent::duplicate($doWrite, ['Fields']);
+    }
 }

--- a/tests/php/ElementFormTest.php
+++ b/tests/php/ElementFormTest.php
@@ -5,6 +5,7 @@ namespace DNADesign\ElementalUserForms\Tests;
 use DNADesign\ElementalUserForms\Model\ElementForm;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\UserForms\Model\EditableFormField\EditableTextField;
 
 class ElementFormTests extends SapphireTest
 {
@@ -16,5 +17,16 @@ class ElementFormTests extends SapphireTest
 
         $this->assertNotNull($fields->fieldByName('Root.FormFields'));
         $this->assertInstanceOf(GridField::class, $fields->fieldByName('Root.FormFields.Fields'));
+    }
+
+    public function testDuplicate()
+    {
+        $element = new ElementForm();
+        $field = new EditableTextField();
+        $field->Title = 'ABC';
+        $field->write();
+        $element->Fields()->add($field);
+        $element2 = $element->duplicate();
+        $this->assertSame('ABC', $element2->Fields()->last()->Title);
     }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-elemental/issues/512

This makes it so that elemental userforms behave the same as regular userforms on duplicate i.e. duplicate child fields too

`Fields` is defined as a has_many on `UserFormFieldEditorExtension` extension on the the `UserForms` trait

Cannot use `private static $cascade_duplicates = ['Fields'];` as that conflicts with `private static $cascade_duplicates = false;` on the `UserForm` trait
