### PR TITLE
Rename test class for psr-4 compatibility

### DIFF
--- a/tests/php/ElementFormTest.php
+++ b/tests/php/ElementFormTest.php
@@ -6,7 +6,7 @@ use DNADesign\ElementalUserForms\Model\ElementForm;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\GridField\GridField;
 
-class ElementFormTests extends SapphireTest
+class ElementFormTest extends SapphireTest
 {
     public function testFormDisplaysInCMS()
     {


### PR DESCRIPTION
Amending test class name to match filename (from `ElementFormTests` to `ElementFormTest`). 

Composer is pinging that `Class DNADesign\ElementalUserForms\Tests\ElementFormTests located in ./vendor/dnadesign/silverstripe-elemental-userforms/tests/php/ElementFormTest.php does not comply with psr-4 autoloading standard. Skipping.`

As it's a test, is it ok to change the class name without semver issues? Or should I resubmit with a change of filename instead?