### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/framework": "4.13.x-dev",
-        "dnadesign/silverstripe-elemental": "4.11.x-dev",
-        "silverstripe/userforms": "5.15.x-dev",
+        "silverstripe/framework": "^4.10",
+        "dnadesign/silverstripe-elemental": "^4.0",
+        "silverstripe/userforms": "^5.0",
         "silverstripe/vendor-plugin": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

## Issue
- https://github.com/silverstripe/.github/issues/33