### PR TITLE
API Use new class_description configuration

### DIFF
--- a/src/Model/ElementForm.php
+++ b/src/Model/ElementForm.php
@@ -30,11 +30,6 @@ class ElementForm extends BaseElement
 
     private static $plural_name = 'forms';
 
-    /**
-     * @deprecated 5.4.0 use class_description instead.
-     */
-    private static $description = 'A user defined form';
-
     private static $class_description = 'A user defined form';
 
     private static $inline_editable = false;


### PR DESCRIPTION
Replaces use of the overly-broadly named `description` configuration in favour of the new `class_description` config added in https://github.com/silverstripe/silverstripe-framework/pull/11460.

See also https://github.com/silverstripe/silverstripe-elemental/pull/1271

## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2947