### PR TITLE
DEP Don't include vendor-plugin as an explicit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
         "php": "^8.3",
         "silverstripe/framework": "^6",
         "dnadesign/silverstripe-elemental": "^6",
-        "silverstripe/userforms": "^7",
-        "silverstripe/vendor-plugin": "^2"
+        "silverstripe/userforms": "^7"
     },
     "require-dev": {
         "silverstripe/recipe-testing": "^4",


### PR DESCRIPTION
We don't directly reference it in code or config, so we can rely on silverstripe/framework having this dependency for us.

## Issue
- https://github.com/silverstripe/.github/issues/311