### PR TITLE
DOC Update PHPDoc to pass linting

### DIFF
--- a/src/Model/ElementForm.php
+++ b/src/Model/ElementForm.php
@@ -3,15 +3,18 @@
 namespace DNADesign\ElementalUserForms\Model;
 
 use SilverStripe\UserForms\Control\UserDefinedFormController;
+use SilverStripe\UserForms\Model\Recipient\EmailRecipient;
+use SilverStripe\UserForms\Model\Submission\SubmittedForm;
 use SilverStripe\UserForms\UserForm;
 use SilverStripe\Control\Controller;
+use SilverStripe\ORM\HasManyList;
 use DNADesign\Elemental\Models\BaseElement;
 use DNADesign\ElementalUserForms\Control\ElementFormController;
 use SilverStripe\Control\RequestHandler;
 
 /**
- * @method SilverStripe\ORM\HasManyList<SilverStripe\UserForms\Model\Recipient\EmailRecipient> EmailRecipients()
- * @method SilverStripe\ORM\HasManyList<SilverStripe\UserForms\Model\Submission\SubmittedForm> Submissions()
+ * @method HasManyList<EmailRecipient> EmailRecipients()
+ * @method HasManyList<SubmittedForm> Submissions()
  */
 class ElementForm extends BaseElement
 {


### PR DESCRIPTION
> [!IMPORTANT]
> This will need to be manually merged up after merging in, as this is the CMS 5.3 branch.
> It is important CI is passing on this branch so that any future high-impact security patches can be automatically tagged. This branch has high impact security support until October.

Fixes linting issues from https://github.com/dnadesign/silverstripe-elemental-userforms/actions/runs/14296646846/job/40064684735

```text
Error: @method annotation 'SilverStripe\ORM\HasManyList<SilverStripe\UserForms\Model\Recipient\EmailRecipient> EmailRecipients()' needs a use statement for class 'HasManyList'.
Error: @method annotation 'SilverStripe\ORM\HasManyList<SilverStripe\UserForms\Model\Submission\SubmittedForm> Submissions()' needs a use statement for class 'HasManyList'.
```

## Issue
- https://github.com/silverstripe/.github/issues/389