### PR TITLE
FIX Remove duplicated use statements

### DIFF
--- a/src/Model/ElementForm.php
+++ b/src/Model/ElementForm.php
@@ -11,9 +11,6 @@ use SilverStripe\ORM\HasManyList;
 use DNADesign\Elemental\Models\BaseElement;
 use DNADesign\ElementalUserForms\Control\ElementFormController;
 use SilverStripe\Control\RequestHandler;
-use SilverStripe\ORM\HasManyList;
-use SilverStripe\UserForms\Model\Recipient\EmailRecipient;
-use SilverStripe\UserForms\Model\Submission\SubmittedForm;
 
 /**
  * @method HasManyList<EmailRecipient> EmailRecipients()


### PR DESCRIPTION
These came through with a merge-up.

Without this PR, `sake db:build` fails.

## Issue
- https://github.com/silverstripe/.github/issues/389