### PR TITLE
FIX Remove duplicated use statements

### DIFF
--- a/src/Model/ElementForm.php
+++ b/src/Model/ElementForm.php
@@ -11,9 +11,6 @@ use SilverStripe\ORM\HasManyList;
 use DNADesign\Elemental\Models\BaseElement;
 use DNADesign\ElementalUserForms\Control\ElementFormController;
 use SilverStripe\Control\RequestHandler;
-use SilverStripe\ORM\HasManyList;
-use SilverStripe\UserForms\Model\Recipient\EmailRecipient;
-use SilverStripe\UserForms\Model\Submission\SubmittedForm;
 
 /**
  * @method HasManyList<EmailRecipient> EmailRecipients()


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/389

Same PR as https://github.com/dnadesign/silverstripe-elemental-userforms/pull/113, though targets the earliest (have confirmed) CMS 5 branch that has this

Issue is that there is duplicated import statements

Fixes inability to dev/build kitchen sink -  PHP Fatal error:  Uncaught PhpParser\Error: Cannot use SilverStripe\ORM\HasManyList as HasManyList because the name is already in use on line 2 in /home/runner/work/silverstripe-elemental-userforms/silverstripe-elemental-userforms/vendor/nikic/php-parser/lib/PhpParser/NameContext.php:71

@silverstripe/core-team
(sorry to ping, I just need someone to give this a quick merge)